### PR TITLE
update Debian.yml for Ubuntu 18+ compatibility as well

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -11,4 +11,4 @@
   apt:
     name: 'libapache2-mod-php5'
     state: present
-  when: ansible_os_family == 'Debian' and ansible_distribution_major_version != '16'
+  when: ansible_os_family == 'Debian' and ansible_distribution_major_version > '14'


### PR DESCRIPTION
Getting the following error when trying to install.sh on Ubuntu 18
```
TASK [opendevshop.aegir-apache : Install Apache2 PHP Mod (Ubuntu 14).] *******************************
fatal: [devshop1.gymwright.com]: FAILED! => {"changed": false, "msg": "No package matching 'libapache2-mod-php5' is available"}
	to retry, use: --limit @/usr/share/devshop/playbook.retry
```

